### PR TITLE
Inject user JWT into CMDB requests

### DIFF
--- a/src/main/java/pl/cyfronet/bazaar/engine/extension/component/SitesService.java
+++ b/src/main/java/pl/cyfronet/bazaar/engine/extension/component/SitesService.java
@@ -1,18 +1,16 @@
 package pl.cyfronet.bazaar.engine.extension.component;
 
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
+import java.util.HashMap;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
-import pl.cyfronet.bazaar.engine.extension.bean.Site;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import pl.cyfronet.bazaar.engine.extension.bean.Site;
+import pl.cyfronet.ltos.repository.CmdbRepository;
 
 /**
  * Created by mszostak on 06.04.17.
@@ -22,9 +20,8 @@ import java.util.HashMap;
 @Scope(value = "session", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class SitesService {
 
-    @Value("${cmdb.url}")
-    private String cmdbUrl;
-
+    @Autowired
+    private CmdbRepository cmdbRepository;
 
     private HashMap<String, Site> sites = null;
 
@@ -35,7 +32,7 @@ public class SitesService {
         sites = new HashMap<>();
 
         try {
-            JSONArray sites = Unirest.get(cmdbUrl+"/cmdb/service/list").asJson().getBody().getObject().getJSONArray("rows");
+            JSONArray sites = cmdbRepository.get("service").getJSONArray("rows");
             for(int i = 0; i < sites.length(); ++i ) {
                 JSONObject site = sites.getJSONObject(i);
                 this.sites.put(site.getString("id"),
@@ -44,10 +41,10 @@ public class SitesService {
                                .build());
             }
             return this.sites;
-        } catch (UnirestException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
-        return null;
+        return new HashMap<>();
     }
 
     public String getSiteName(String siteId) {

--- a/src/main/java/pl/cyfronet/bazaar/engine/extension/metric/SiteSelectMetric.java
+++ b/src/main/java/pl/cyfronet/bazaar/engine/extension/metric/SiteSelectMetric.java
@@ -8,10 +8,11 @@ import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.security.oauth2.client.OAuth2RestOperations;
 
 import com.agreemount.bean.metric.Metric;
 import com.agreemount.bean.metric.MetricOption;
+
+import pl.cyfronet.ltos.repository.CmdbRepository;
 
 @lombok.Getter
 @lombok.Setter
@@ -28,15 +29,13 @@ public class SiteSelectMetric extends Metric<String> {
     private SiteType siteType;
     public String cmdbUrl;
 
-    // Ugly hack to inject rest template proxy
-    public static OAuth2RestOperations restTemplate;
+    public static CmdbRepository cmdbRepository;
 
     public List<MetricOption> getOptions() {
         JSONArray sites = null;
         ArrayList<MetricOption> ret = new ArrayList<>();
         try {
-            Map response = restTemplate.getForObject(cmdbUrl + "/cmdb/service/filters/type/"+siteType, Map.class);
-            sites = new JSONObject(response).getJSONArray("rows");
+            sites = cmdbRepository.get("service", "type", siteType.toString()).getJSONArray("rows");
         } catch (Exception e) {
             //@TODO@ - provide message to frontend
             e.printStackTrace();

--- a/src/main/java/pl/cyfronet/bazaar/engine/extension/metric/SiteSelectMetric.java
+++ b/src/main/java/pl/cyfronet/bazaar/engine/extension/metric/SiteSelectMetric.java
@@ -1,19 +1,17 @@
 package pl.cyfronet.bazaar.engine.extension.metric;
 
-import com.agreemount.bean.metric.Metric;
-import com.agreemount.bean.metric.MetricOption;
-import com.agreemount.bean.metric.SelectMetric;
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.data.annotation.Transient;
-import org.springframework.stereotype.Service;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
 
-import java.util.*;
+import com.agreemount.bean.metric.Metric;
+import com.agreemount.bean.metric.MetricOption;
 
 @lombok.Getter
 @lombok.Setter
@@ -30,12 +28,16 @@ public class SiteSelectMetric extends Metric<String> {
     private SiteType siteType;
     public String cmdbUrl;
 
+    // Ugly hack to inject rest template proxy
+    public static OAuth2RestOperations restTemplate;
+
     public List<MetricOption> getOptions() {
         JSONArray sites = null;
-        ArrayList<MetricOption> ret = new ArrayList<MetricOption>();
+        ArrayList<MetricOption> ret = new ArrayList<>();
         try {
-            sites = Unirest.get(cmdbUrl + "/cmdb/service/filters/type/"+siteType).asJson().getBody().getObject().getJSONArray("rows");
-        } catch (UnirestException e) {
+            Map response = restTemplate.getForObject(cmdbUrl + "/cmdb/service/filters/type/"+siteType, Map.class);
+            sites = new JSONObject(response).getJSONArray("rows");
+        } catch (Exception e) {
             //@TODO@ - provide message to frontend
             e.printStackTrace();
             return ret;

--- a/src/main/java/pl/cyfronet/ltos/repository/CmdbRepository.java
+++ b/src/main/java/pl/cyfronet/ltos/repository/CmdbRepository.java
@@ -1,0 +1,36 @@
+package pl.cyfronet.ltos.repository;
+
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
+import org.springframework.stereotype.Component;
+
+import pl.cyfronet.bazaar.engine.extension.metric.SiteSelectMetric;
+
+@Component
+public class CmdbRepository {
+    @Value("${cmdb.url}")
+    private String cmdbUrl;
+
+    @Autowired
+    private OAuth2RestOperations restTemplate;
+
+    public JSONObject get(String type, String fieldName, String fieldValue) {
+        return new JSONObject(restTemplate
+                .getForObject(cmdbUrl + "/cmdb/" + type + "/filters/" + fieldName + "/" + fieldValue, Map.class));
+    }
+
+    public JSONObject get(String type) {
+        return new JSONObject(restTemplate.getForObject(cmdbUrl + "/cmdb/" + type + "/list", Map.class));
+    }
+
+    @PostConstruct
+    private void injectIntoEngine() {
+        SiteSelectMetric.cmdbRepository = this;
+    }
+}

--- a/src/main/java/pl/cyfronet/ltos/security/OpenIDConnectAuthenticationFilter.java
+++ b/src/main/java/pl/cyfronet/ltos/security/OpenIDConnectAuthenticationFilter.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
 import javax.net.ssl.HttpsURLConnection;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -29,7 +28,6 @@ import com.agreemount.bean.identity.Identity;
 import com.agreemount.bean.identity.provider.IdentityProvider;
 import com.google.common.base.Preconditions;
 
-import pl.cyfronet.bazaar.engine.extension.metric.SiteSelectMetric;
 import pl.cyfronet.ltos.bean.Role;
 import pl.cyfronet.ltos.bean.User;
 import pl.cyfronet.ltos.repository.UserRepository;
@@ -79,12 +77,6 @@ public class OpenIDConnectAuthenticationFilter extends AbstractAuthenticationPro
         setAuthenticationFailureHandler(new OpenIDConnectAuthenticationFailureHandler());
 
         setAuthenticationManager(authentication -> authentication);
-    }
-
-    @PostConstruct
-    private void injectRestTemplateIntoMetrics() {
-        // Ugly hack to inject rest template proxy
-        SiteSelectMetric.restTemplate = restTemplate;
     }
 
     @Override

--- a/src/main/java/pl/cyfronet/ltos/security/OpenIDConnectAuthenticationFilter.java
+++ b/src/main/java/pl/cyfronet/ltos/security/OpenIDConnectAuthenticationFilter.java
@@ -1,11 +1,19 @@
 package pl.cyfronet.ltos.security;
 
-import com.agreemount.bean.identity.Identity;
-import com.agreemount.bean.identity.provider.IdentityProvider;
-import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.net.ssl.HttpsURLConnection;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -16,21 +24,15 @@ import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+
+import com.agreemount.bean.identity.Identity;
+import com.agreemount.bean.identity.provider.IdentityProvider;
+import com.google.common.base.Preconditions;
+
+import pl.cyfronet.bazaar.engine.extension.metric.SiteSelectMetric;
 import pl.cyfronet.ltos.bean.Role;
 import pl.cyfronet.ltos.bean.User;
 import pl.cyfronet.ltos.repository.UserRepository;
-import pl.cyfronet.ltos.repository.RoleRepository;
-
-import javax.net.ssl.HttpsURLConnection;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import pl.cyfronet.ltos.security.AuthenticationProviderDev.UserOperations;
 
 /**
@@ -77,6 +79,12 @@ public class OpenIDConnectAuthenticationFilter extends AbstractAuthenticationPro
         setAuthenticationFailureHandler(new OpenIDConnectAuthenticationFailureHandler());
 
         setAuthenticationManager(authentication -> authentication);
+    }
+
+    @PostConstruct
+    private void injectRestTemplateIntoMetrics() {
+        // Ugly hack to inject rest template proxy
+        SiteSelectMetric.restTemplate = restTemplate;
     }
 
     @Override


### PR DESCRIPTION
Unfortunately ugly hack was used here to make it work. Metric definition are not managed by spring, though static field was used to inject OAuth2RestOperations. This is a proxy where user JWT token is already injected.

@bwilk I was unable to make your "not so ugly hack" for injecting spring managed object into Metric works for this particular example. That is why static field was used. 